### PR TITLE
Feedback from Louis and Milan

### DIFF
--- a/analysis/cohort_joiner.py
+++ b/analysis/cohort_joiner.py
@@ -31,8 +31,8 @@ def match_paths(pattern):
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("lhs_paths", type=match_paths)
-    parser.add_argument("rhs_paths", type=match_paths)
+    parser.add_argument("--lhs_paths", required=True, type=match_paths)
+    parser.add_argument("--rhs_paths", required=True, type=match_paths)
     return parser.parse_args()
 
 

--- a/analysis/cohort_joiner.py
+++ b/analysis/cohort_joiner.py
@@ -31,8 +31,8 @@ def match_paths(pattern):
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--lhs_paths", required=True, type=match_paths)
-    parser.add_argument("--rhs_paths", required=True, type=match_paths)
+    parser.add_argument("--lhs", dest="lhs_paths", required=True, type=match_paths)
+    parser.add_argument("--rhs", dest="rhs_paths", required=True, type=match_paths)
     return parser.parse_args()
 
 

--- a/analysis/cohort_joiner.py
+++ b/analysis/cohort_joiner.py
@@ -31,8 +31,22 @@ def match_paths(pattern):
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--lhs", dest="lhs_paths", required=True, type=match_paths)
-    parser.add_argument("--rhs", dest="rhs_paths", required=True, type=match_paths)
+    parser.add_argument(
+        "--lhs",
+        dest="lhs_paths",
+        required=True,
+        type=match_paths,
+        metavar="LHS_PATTERN",
+        help="Glob pattern for matching one or more dataframes that will form the left-hand side of the join",
+    )
+    parser.add_argument(
+        "--rhs",
+        dest="rhs_paths",
+        required=True,
+        type=match_paths,
+        metavar="RHS_PATTERN",
+        help="Glob pattern for matching one dataframe that will form the right-hand side of the join",
+    )
     return parser.parse_args()
 
 

--- a/project.yaml
+++ b/project.yaml
@@ -5,19 +5,27 @@ expectations:
 
 actions:
   generate_cohort:
-    run: cohortextractor:latest generate_cohort --study-definition study_definition --index-date-range "2021-01-01 to 2021-06-30 by month"
+    run: >
+      cohortextractor:latest generate_cohort
+        --study-definition study_definition
+        --index-date-range "2021-01-01 to 2021-06-30 by month"
     outputs:
       highly_sensitive:
         cohort: output/input_2021-*.csv
 
   generate_ethnicity_cohort:
-    run: cohortextractor:latest generate_cohort --study-definition study_definition_ethnicity
+    run: >
+      cohortextractor:latest generate_cohort
+        --study-definition study_definition_ethnicity
     outputs:
       highly_sensitive:
         cohort: output/input_ethnicity.csv
 
   join_cohorts:
-    run: python:latest analysis/cohort_joiner.py output/input_2021-*.csv output/input_ethnicity.csv
+    run: >
+      python:latest analysis/cohort_joiner.py
+        output/input_2021-*.csv
+        output/input_ethnicity.csv
     needs: [generate_cohort, generate_ethnicity_cohort]
     outputs:
       highly_sensitive:

--- a/project.yaml
+++ b/project.yaml
@@ -24,8 +24,8 @@ actions:
   join_cohorts:
     run: >
       python:latest analysis/cohort_joiner.py
-        --lhs_paths output/input_2021-*.csv
-        --rhs_paths output/input_ethnicity.csv
+        --lhs output/input_2021-*.csv
+        --rhs output/input_ethnicity.csv
     needs: [generate_cohort, generate_ethnicity_cohort]
     outputs:
       highly_sensitive:

--- a/project.yaml
+++ b/project.yaml
@@ -24,8 +24,8 @@ actions:
   join_cohorts:
     run: >
       python:latest analysis/cohort_joiner.py
-        output/input_2021-*.csv
-        output/input_ethnicity.csv
+        --lhs_paths output/input_2021-*.csv
+        --rhs_paths output/input_ethnicity.csv
     needs: [generate_cohort, generate_ethnicity_cohort]
     outputs:
       highly_sensitive:

--- a/tests/test_cohort_joiner.py
+++ b/tests/test_cohort_joiner.py
@@ -86,17 +86,16 @@ def test_left_join():
     pandas_testing.assert_frame_equal(exp_dataframe, obs_dataframe)
 
 
-@pytest.mark.parametrize(
-    "pattern,matched_names",
-    [
-        ("input_2021-*.csv", ["input_2021-01-01.csv"]),
-    ],
-)
-def test_match_paths(tmp_path, pattern, matched_names):
+def test_parse_args(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["cohort_joiner.py", "input_2021-*.csv", "input_ethnicity.csv"],
+    )
     for name in ["input_2021-01-01.csv", "input_ethnicity.csv"]:
-        path = tmp_path / name
-        path.touch()
+        pathlib.Path(name).touch()
 
-    exp_paths = [tmp_path / matched_name for matched_name in matched_names]
-    obs_paths = cohort_joiner.match_paths(str(tmp_path / pattern))
-    assert exp_paths == obs_paths
+    args = cohort_joiner.parse_args()
+
+    assert args.lhs_paths == [tmp_path / "input_2021-01-01.csv"]
+    assert args.rhs_paths == [tmp_path / "input_ethnicity.csv"]

--- a/tests/test_cohort_joiner.py
+++ b/tests/test_cohort_joiner.py
@@ -90,7 +90,13 @@ def test_parse_args(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
         "sys.argv",
-        ["cohort_joiner.py", "input_2021-*.csv", "input_ethnicity.csv"],
+        [
+            "cohort_joiner.py",
+            "--lhs_paths",
+            "input_2021-*.csv",
+            "--rhs_paths",
+            "input_ethnicity.csv",
+        ],
     )
     for name in ["input_2021-01-01.csv", "input_ethnicity.csv"]:
         pathlib.Path(name).touch()

--- a/tests/test_cohort_joiner.py
+++ b/tests/test_cohort_joiner.py
@@ -92,9 +92,9 @@ def test_parse_args(tmp_path, monkeypatch):
         "sys.argv",
         [
             "cohort_joiner.py",
-            "--lhs_paths",
+            "--lhs",
             "input_2021-*.csv",
-            "--rhs_paths",
+            "--rhs",
             "input_ethnicity.csv",
         ],
     )


### PR DESCRIPTION
Some improvements to the invocation of `cohort-joiner`, following feedback from @LFISHER7 and @milanwiedemann. Given the minimal amount of configuration, I thought that

```yaml
join_cohorts:
  run: >
    python:latest analysis/cohort_joiner.py
      --lhs output/input_2021-*.csv
      --rhs output/input_ethnicity.csv
  needs: [generate_cohort, generate_ethnicity_cohort]
  outputs:
    highly_sensitive:
      cohort: output/input_2021-*_joined.csv
```

was better than

```yaml
join_cohorts:
  run: python:latest analysis/cohort_joiner.py
  config:
    lhs: output/input_2021-*.csv
    rhs: output/input_ethnicity.csv
  needs: [generate_cohort, generate_ethnicity_cohort]
  outputs:
    highly_sensitive:
      cohort: output/input_2021-*_joined.csv
```

because the former is more consistent with

```yaml
generate_cohort:
  run: >
    cohortextractor:latest generate_cohort
      --study-definition study_definition
      --index-date-range "2021-01-01 to 2021-06-30 by month"
  outputs:
    highly_sensitive:
      cohort: output/input_2021-*.csv
```