### PR TITLE
Convert to reusable action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: "actions/setup-python@v2"
+      - uses: actions/setup-python@v2
         with:
           python-version: "3.8"
-          cache: "pip"
+          cache: pip
           cache-dependency-path: requirements.*.txt
       - uses: extractions/setup-just@v1
       - name: Check formatting, linting and import sorting
@@ -27,15 +27,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: "actions/setup-python@v2"
+      - uses: actions/setup-python@v2
         with:
           python-version: "3.8"
-          cache: "pip"
+          cache: pip
           cache-dependency-path: requirements.*.txt
       - uses: extractions/setup-just@v1
       - name: Run tests
-        run: |
-          just test
+        run: just test
 
   tag-new-version:
     needs: [test]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,3 +36,15 @@ jobs:
       - name: Run tests
         run: |
           just test
+
+  tag-new-version:
+    needs: [test]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Tag new version
+        uses: mathieudutour/github-tag-action@d745f2e74aaf1ee82e747b181f7a0967978abee0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          create_annotated_tag: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
 
 jobs:
   check:

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -20,18 +20,68 @@ just # Shortcut for just --list
 
 ## Development
 
-Set up a local development environment with:
+Set up a local development environment with
 
 ```sh
 just devenv
 ```
 
-## Tests
+and create a new branch.
+Then, iteratively:
 
-Run the tests with:
+* Make changes to the code
+* Run the tests with
 
-```sh
-just test
+  ```sh
+  just test
+  ```
+
+* Check the code for issues with
+
+  ```sh
+  just check
+  ```
+
+* Fix any issues with
+
+  ```sh
+  just fix
+  ```
+
+* Commit the changes
+
+Finally, push the branch to GitHub and open a pull request against the `main` branch.
+
+## Tagging a new version
+
+cohort-joiner follows [Semantic Versioning, v2.0.0]().
+
+A new __patch__ version is automatically tagged when a group of commits is pushed to the `main` branch;
+for example, when a group that comprises a pull request is merged.
+Alternatively, a new patch version is tagged for each commit in the group that has a message title prefixed with `fix`.
+For example, a commit with the following message title would tag a new patch version when it is pushed to the `main` branch:
+
+```
+fix: a bug fix
 ```
 
+A new __minor__ version is tagged for each commit in the group that has a message title prefixed with `feat`.
+For example, a commit with the following message title would tag a new minor version when it is pushed to the `main` branch:
+
+```
+feat: a new feature
+```
+
+A new __major__ version is tagged for each commit in the group that has `BREAKING CHANGE` in its message body.
+For example, a commit with the following message body would tag a new major version:
+
+```
+Remove a function
+
+BREAKING CHANGE: Removing a function is not backwards-compatible.
+```
+
+Whilst there are other prefixes besides `fix` and `feat`, they do not tag new versions.
+
 [1]: https://github.com/casey/just/
+[2]: https://semver.org/spec/v2.0.0.html

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ join_cohorts:
       cohort: output/input_2021-*_joined.csv
 ```
 
+For each left-hand cohort file, there will now be a corresponding joined file.
+For example, given a left-hand cohort file called `input_2021-01-01.csv`, there will now be a corresponding joined file called `input_2021-01-01_joined.csv`.
+
 [1]: https://github.com/opensafely-actions/cohort-joiner/tags
 [cohort-extractor]: https://docs.opensafely.org/actions-cohortextractor/
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Extracting and joining the cohorts in this way is more efficient than several we
 
 ## Usage
 
-[_project.yaml_][] in cohort-joiner's GitHub repository demonstrates how to use cohort-joiner.
 In summary:
 
 * Use [cohort-extractor][] to extract the left-hand cohorts.
@@ -19,7 +18,49 @@ In summary:
   This is a single extract for variables that are not expected to change, such as ethnicity.
 * Use cohort-joiner to join the cohorts.
 
-[_project.yaml_]: https://github.com/opensafely-actions/cohort-joiner
+Let's walk through an example _project.yaml_.
+
+The following cohort-extractor action extracts the left-hand cohorts:
+
+```yaml
+generate_cohort:
+  run: >
+    cohortextractor:latest generate_cohort
+      --study-definition study_definition
+      --index-date-range "2021-01-01 to 2021-06-30 by month"
+  outputs:
+    highly_sensitive:
+      cohort: output/input_2021-*.csv
+```
+
+The following cohort-extractor action extracts the right hand cohort:
+
+```yaml
+generate_ethnicity_cohort:
+  run: >
+    cohortextractor:latest generate_cohort
+      --study-definition study_definition_ethnicity
+  outputs:
+    highly_sensitive:
+      cohort: output/input_ethnicity.csv
+```
+
+Finally, the following cohort-joiner reusable action joins the cohorts.
+Remember to replace `[version]` with [a cohort-joiner version][1]:
+
+```yaml
+join_cohorts:
+  run: >
+    cohort-joiner:[version]
+      --lhs output/input_2021-*.csv
+      --rhs output/input_ethnicity.csv
+  needs: [generate_cohort, generate_ethnicity_cohort]
+  outputs:
+    highly_sensitive:
+      cohort: output/input_2021-*_joined.csv
+```
+
+[1]: https://github.com/opensafely-actions/cohort-joiner/tags
 [cohort-extractor]: https://docs.opensafely.org/actions-cohortextractor/
 
 ## Notes for developers

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,1 @@
+run: python:latest analysis/cohort_joiner.py

--- a/project.yaml
+++ b/project.yaml
@@ -4,6 +4,8 @@ expectations:
   population_size: 1000
 
 actions:
+  # These actions are copied-and-pasted into README.md for user-facing documentation.
+  # If you change them here, then please change them there.
   generate_cohort:
     run: >
       cohortextractor:latest generate_cohort
@@ -22,6 +24,8 @@ actions:
         cohort: output/input_ethnicity.csv
 
   join_cohorts:
+    # For user-facing documentation, call:
+    # cohort-joiner:[version]
     run: >
       python:latest analysis/cohort_joiner.py
         --lhs output/input_2021-*.csv


### PR DESCRIPTION
This PR converts `cohort-joiner` to a reusable action, following the checklist in #6. I've taken a simple approach to documentation and tagging new versions, based on my experience with opensafely-actions/cohort-report#60.

In that PR, I added a GitHub workflow that tagged a new version and updated the documentation. Consequently, a user could copy-and-paste from the documentation into their own study, confident that the version string was the most recent. However, the developer had to remember that the workflow created a new commit (as well as a new tag), which they needed to pull. More annoyingly, the workflow broke 🤦🏻‍♂️ (opensafely-actions/cohort-report#70).

To save you (and me) from more pain, my simple approach to tagging new versions is to use [github-tag-action](https://github.com/mathieudutour/github-tag-action) with the default configuration (almost). No updating the documentation; no creating new commits. If a user copies-and-pastes from the documentation, then they will have to edit what they have copied-and-pasted. This is intentional!

For even more simplicity, the `tag-new-version` job is in `main.yml`. Because we don't want to tag a new version on each push, this workflow is now restricted to the `main` branch. See 3af23d5 for more information.

Closes #6