### PR TITLE
Restrict dependabot to development dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    allow:
+      - dependency-type: "development"
     open-pull-requests-limit: 20


### PR DESCRIPTION
A reusable action is executed within a container that is created from
the python-docker image. Consequently, a reusable action's production
dependencies must match the versions available within the container; not
the latest available versions.

Dependabot doesn't know this, so will open PRs when a reusable action's
production dependencies don't match the latest available versions.
Merging these PRs could break a reusable action, as the latest available
versions may differ from the versions available within the container.
For this reason, we restrict dependabot to development dependencies.