### PR TITLE
Add option to overwrite left-hand cohort files

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,16 @@ join_cohorts:
     cohort-joiner:[version]
       --lhs output/input_2021-*.csv
       --rhs output/input_ethnicity.csv
+      --overwrite
   needs: [generate_cohort, generate_ethnicity_cohort]
   outputs:
     highly_sensitive:
-      cohort: output/input_2021-*_joined.csv
+      cohort: output/input_*.csv
 ```
 
-For each left-hand cohort file, there will now be a corresponding joined file.
-For example, given a left-hand cohort file called `input_2021-01-01.csv`, there will now be a corresponding joined file called `input_2021-01-01_joined.csv`.
+With the `--overwrite` argument, each left-hand cohort file will be overwritten.
+Without this argument, each left-hand cohort file will have a corresponding joined file.
+For example, the left-hand cohort file called `input_2021-01-01.csv` will have a corresponding joined file called `input_2021-01-01_joined.csv`.
 
 [1]: https://github.com/opensafely-actions/cohort-joiner/tags
 [cohort-extractor]: https://docs.opensafely.org/actions-cohortextractor/

--- a/analysis/cohort_joiner.py
+++ b/analysis/cohort_joiner.py
@@ -65,6 +65,11 @@ def parse_args():
         metavar="RHS_PATTERN",
         help="Glob pattern for matching one dataframe that will form the right-hand side of the join",
     )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite the dataframes matched by the lhs glob pattern",
+    )
     return parser.parse_args()
 
 
@@ -72,12 +77,16 @@ def main():
     args = parse_args()
     lhs_paths = args.lhs_paths
     rhs_path = args.rhs_paths[0]
+    overwrite = args.overwrite
 
     rhs_dataframe = read_dataframe(rhs_path)
     for lhs_path in lhs_paths:
         lhs_dataframe = read_dataframe(lhs_path)
         lhs_dataframe = left_join(lhs_dataframe, rhs_dataframe)
-        new_lhs_path = get_new_path(lhs_path)
+        if overwrite:
+            new_lhs_path = lhs_path
+        else:
+            new_lhs_path = get_new_path(lhs_path)
         write_dataframe(lhs_dataframe, new_lhs_path)
 
 

--- a/project.yaml
+++ b/project.yaml
@@ -30,7 +30,8 @@ actions:
       python:latest analysis/cohort_joiner.py
         --lhs output/input_2021-*.csv
         --rhs output/input_ethnicity.csv
+        --overwrite
     needs: [generate_cohort, generate_ethnicity_cohort]
     outputs:
       highly_sensitive:
-        cohort: output/input_2021-*_joined.csv
+        cohort: output/input_*.csv

--- a/tests/test_cohort_joiner.py
+++ b/tests/test_cohort_joiner.py
@@ -131,7 +131,14 @@ def test_left_join():
     pandas_testing.assert_frame_equal(exp_dataframe, obs_dataframe)
 
 
-def test_parse_args(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    "flags,dest,value",
+    [
+        ([], "overwrite", False),
+        (["--overwrite"], "overwrite", True),
+    ],
+)
+def test_parse_args(tmp_path, monkeypatch, flags, dest, value):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
         "sys.argv",
@@ -141,7 +148,8 @@ def test_parse_args(tmp_path, monkeypatch):
             "input_2021-*.csv",
             "--rhs",
             "input_ethnicity.csv",
-        ],
+        ]
+        + flags,
     )
     for name in ["input_2021-01-01.csv", "input_ethnicity.csv"]:
         pathlib.Path(name).touch()
@@ -150,3 +158,4 @@ def test_parse_args(tmp_path, monkeypatch):
 
     assert args.lhs_paths == [tmp_path / "input_2021-01-01.csv"]
     assert args.rhs_paths == [tmp_path / "input_ethnicity.csv"]
+    assert getattr(args, dest) is value


### PR DESCRIPTION
This option allows left-hand cohort files to be passed to the measures framework.

I'd like to know whether you feel `overwrite` is a good name for the argument. We could name it `replace`, for example.

Closes #14