### PR TITLE
Add `--output-dir` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In summary:
   such as whether a patient has experienced an <abbr title="Systolic Blood Pressure">SBP</abbr> event.
 * Use cohort-extractor to extract the right hand cohort.
   This is a single extract for variables that are not expected to change, such as ethnicity.
-* Use cohort-joiner to join the cohorts.
+* Use cohort-joiner to join the cohorts, and then to save them to an output directory.
 
 Let's walk through an example _project.yaml_.
 
@@ -45,7 +45,7 @@ generate_ethnicity_cohort:
       cohort: output/input_ethnicity.csv
 ```
 
-Finally, the following cohort-joiner reusable action joins the cohorts.
+Finally, the following cohort-joiner reusable action joins the cohorts, and then saves them to an output directory.
 Remember to replace `[version]` with [a cohort-joiner version][1]:
 
 ```yaml
@@ -54,14 +54,12 @@ join_cohorts:
     cohort-joiner:[version]
       --lhs output/input_2021-*.csv
       --rhs output/input_ethnicity.csv
+      --output-dir output/joined
   needs: [generate_cohort, generate_ethnicity_cohort]
   outputs:
     highly_sensitive:
-      cohort: output/input_2021-*_joined.csv
+      cohort: output/joined/input_2021-*.csv
 ```
-
-For each left-hand cohort file, there will now be a corresponding joined file.
-For example, given a left-hand cohort file called `input_2021-01-01.csv`, there will now be a corresponding joined file called `input_2021-01-01_joined.csv`.
 
 [1]: https://github.com/opensafely-actions/cohort-joiner/tags
 [cohort-extractor]: https://docs.opensafely.org/actions-cohortextractor/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ In summary:
 * Use cohort-extractor to extract the right hand cohort.
   This is a single extract for variables that are not expected to change, such as ethnicity.
 * Use cohort-joiner to join the cohorts, and then to save them to an output directory.
+* Optionally, use cohort-extractor to generate one or more measures from the joined cohorts.
 
 Let's walk through an example _project.yaml_.
 
@@ -45,7 +46,7 @@ generate_ethnicity_cohort:
       cohort: output/input_ethnicity.csv
 ```
 
-Finally, the following cohort-joiner reusable action joins the cohorts, and then saves them to an output directory.
+The following cohort-joiner reusable action joins the cohorts, and then saves them to an output directory.
 Remember to replace `[version]` with [a cohort-joiner version][1]:
 
 ```yaml
@@ -59,6 +60,20 @@ join_cohorts:
   outputs:
     highly_sensitive:
       cohort: output/joined/input_2021-*.csv
+```
+
+Optionally, the following cohort-extractor action generates one or more measures from the joined cohorts:
+
+```yaml
+generate_measures:
+  run: >
+    cohortextractor:latest generate_measures
+      --study-definition study_definition
+      --output-dir output/joined
+  needs: [join_cohorts]
+  outputs:
+    moderately_sensitive:
+      measure: output/joined/measure_*.csv
 ```
 
 [1]: https://github.com/opensafely-actions/cohort-joiner/tags

--- a/analysis/cohort_joiner.py
+++ b/analysis/cohort_joiner.py
@@ -43,8 +43,12 @@ def left_join(lhs_dataframe, rhs_dataframe):
     return lhs_dataframe.merge(rhs_dataframe, how="left", on="patient_id")
 
 
+def get_path(*args):
+    return pathlib.Path(*args).resolve()
+
+
 def match_paths(pattern):
-    return [pathlib.Path(x).resolve() for x in glob.glob(pattern)]
+    return [get_path(x) for x in glob.glob(pattern)]
 
 
 def parse_args():

--- a/analysis/cohort_joiner.py
+++ b/analysis/cohort_joiner.py
@@ -33,12 +33,6 @@ def get_extension(path):
     return "".join(path.suffixes)
 
 
-def get_new_path(old_path, suffix="_joined"):
-    ext = get_extension(old_path)
-    name = old_path.name.split(ext)[0]
-    return old_path.with_name(f"{name}{suffix}{ext}")
-
-
 def left_join(lhs_dataframe, rhs_dataframe):
     return lhs_dataframe.merge(rhs_dataframe, how="left", on="patient_id")
 
@@ -59,7 +53,7 @@ def parse_args():
         required=True,
         type=match_paths,
         metavar="LHS_PATTERN",
-        help="Glob pattern for matching one or more dataframes that will form the left-hand side of the join",
+        help="Glob pattern for matching one or more input dataframes that will form the left-hand side of the join",
     )
     parser.add_argument(
         "--rhs",
@@ -67,22 +61,37 @@ def parse_args():
         required=True,
         type=match_paths,
         metavar="RHS_PATTERN",
-        help="Glob pattern for matching one dataframe that will form the right-hand side of the join",
+        help="Glob pattern for matching one input dataframe that will form the right-hand side of the join",
+    )
+    parser.add_argument(
+        "--output-dir",
+        dest="output_path",
+        default="output/joined",
+        type=get_path,
+        help="The output directory. If it doesn't exist, then it will be created",
     )
     return parser.parse_args()
+
+
+def check_paths(lhs_paths, rhs_path, output_path):
+    if any(output_path == path.parent for path in lhs_paths + [rhs_path]):
+        raise ValueError("The output directory cannot contain the input dataframes")
 
 
 def main():
     args = parse_args()
     lhs_paths = args.lhs_paths
     rhs_path = args.rhs_paths[0]
+    output_path = args.output_path
+    check_paths(lhs_paths, rhs_path, output_path)
 
     rhs_dataframe = read_dataframe(rhs_path)
     for lhs_path in lhs_paths:
         lhs_dataframe = read_dataframe(lhs_path)
         lhs_dataframe = left_join(lhs_dataframe, rhs_dataframe)
-        new_lhs_path = get_new_path(lhs_path)
-        write_dataframe(lhs_dataframe, new_lhs_path)
+        # We only make output_path when there's a lhs_dataframe to write to it
+        output_path.mkdir(parents=True, exist_ok=True)
+        write_dataframe(lhs_dataframe, output_path / lhs_path.name)
 
 
 if __name__ == "__main__":

--- a/analysis/study_definition.py
+++ b/analysis/study_definition.py
@@ -25,13 +25,4 @@ study = StudyDefinition(
         between=["index_date", "index_date"],
         return_expectations={"incidence": 0.1},
     ),
-    sbp_event_code=patients.with_these_clinical_events(
-        codelist=sbp_codelist,
-        between=["index_date", "index_date"],
-        returning="code",
-        return_expectations={
-            "category": {"ratios": {x: 1 / len(sbp_codelist) for x in sbp_codelist}},
-            "incidence": 0.1,
-        },
-    ),
 )

--- a/analysis/study_definition.py
+++ b/analysis/study_definition.py
@@ -1,4 +1,4 @@
-from cohortextractor import StudyDefinition, codelist_from_csv, patients
+from cohortextractor import Measure, StudyDefinition, codelist_from_csv, patients
 
 
 sbp_codelist = codelist_from_csv(
@@ -20,9 +20,27 @@ study = StudyDefinition(
         on_or_before="index_date",
         return_expectations={"incidence": 0.1},
     ),
+    stp_code=patients.registered_practice_as_of(
+        date="index_date",
+        returning="stp_code",
+        return_expectations={
+            "category": {
+                "ratios": {f"STP{x}": 1 / 50 for x in range(50)},
+            },
+        },
+    ),
     has_sbp_event=patients.with_these_clinical_events(
         codelist=sbp_codelist,
         between=["index_date", "index_date"],
         return_expectations={"incidence": 0.1},
     ),
 )
+
+measures = [
+    Measure(
+        id="has_sbp_event_by_stp_code",
+        numerator="has_sbp_event",
+        denominator="population",
+        group_by="stp_code",
+    ),
+]

--- a/project.yaml
+++ b/project.yaml
@@ -35,3 +35,13 @@ actions:
     outputs:
       highly_sensitive:
         cohort: output/joined/input_2021-*.csv
+
+  generate_measures:
+    run: >
+      cohortextractor:latest generate_measures
+        --study-definition study_definition
+        --output-dir output/joined
+    needs: [join_cohorts]
+    outputs:
+      moderately_sensitive:
+        measure: output/joined/measure_*.csv

--- a/project.yaml
+++ b/project.yaml
@@ -30,7 +30,8 @@ actions:
       python:latest analysis/cohort_joiner.py
         --lhs output/input_2021-*.csv
         --rhs output/input_ethnicity.csv
+        --output-dir output/joined
     needs: [generate_cohort, generate_ethnicity_cohort]
     outputs:
       highly_sensitive:
-        cohort: output/input_2021-*_joined.csv
+        cohort: output/joined/input_2021-*.csv

--- a/tests/test_cohort_joiner.py
+++ b/tests/test_cohort_joiner.py
@@ -94,17 +94,6 @@ class TestWriteDataframe:
             cohort_joiner.write_dataframe(dataframe, xlsx_path)
 
 
-@pytest.mark.parametrize(
-    "old_name,new_name",
-    [
-        ("input.csv", "input_joined.csv"),
-        ("input.csv.gz", "input_joined.csv.gz"),
-    ],
-)
-def test_get_new_path(tmp_path, old_name, new_name):
-    assert tmp_path / new_name == cohort_joiner.get_new_path(tmp_path / old_name)
-
-
 def test_left_join():
     lhs_dataframe = pandas.DataFrame(
         {
@@ -150,3 +139,19 @@ def test_parse_args(tmp_path, monkeypatch):
 
     assert args.lhs_paths == [tmp_path / "input_2021-01-01.csv"]
     assert args.rhs_paths == [tmp_path / "input_ethnicity.csv"]
+    assert args.output_path == tmp_path / "output" / "joined"
+
+
+class TestCheckPaths:
+    def test_output_contains_input(self, tmp_path):
+        lhs_paths = [tmp_path / "input_2021-01-01.csv"]
+        rhs_path = tmp_path / "input_ethnicity.csv"
+        output_path = tmp_path
+        with pytest.raises(ValueError):
+            cohort_joiner.check_paths(lhs_paths, rhs_path, output_path)
+
+    def test_output_does_not_contain_input(self, tmp_path):
+        lhs_paths = [tmp_path / "input_2021-01-01.csv"]
+        rhs_path = tmp_path / "input_ethnicity.csv"
+        output_path = tmp_path / "joined"
+        assert cohort_joiner.check_paths(lhs_paths, rhs_path, output_path) is None


### PR DESCRIPTION
As @LindaNab pointed out, we'd like to use the cohorts produced by cohort-joiner, or the _output dataframes_, with [the measures framework](https://docs.opensafely.org/measures/). We could overwrite the cohorts produced by cohort-extractor, or the _input dataframes_ (#17) but this makes it hard to construct an audit trail. Instead, we add the `--output-dir` argument and insist that the output dataframes are not written to the same directory as the input dataframes.

Because cohort-joiner is as much a workflow as a reusable action, we illustrate it with a study. This study is cohort-joiner's use case and is copied-and-pasted into README.md.