### PR TITLE
Call python when invoking cohort-joiner

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,1 +1,1 @@
-run: python:latest analysis/cohort_joiner.py
+run: python:latest python analysis/cohort_joiner.py


### PR DESCRIPTION
I didn't think it was necessary, but adding it isn't going to hurt.