### PR TITLE
Decrease dependabot frequency to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     allow:
       - dependency-type: "development"
     open-pull-requests-limit: 20


### PR DESCRIPTION
We don't need to update our development dependencies weekly; monthly
should be sufficient.