### PR TITLE
Fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,8 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     allow:
       - dependency-type: "development"
+      - dependency-name: "opensafely-cohort-extractor"
     open-pull-requests-limit: 20

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,3 @@ updates:
     allow:
       - dependency-type: "development"
     open-pull-requests-limit: 20
-
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "opensafely-cohort-extractor"
-    open-pull-requests-limit: 20


### PR DESCRIPTION
It's not possible to have two entries for the same package-ecosystem (for the same directory and target-branch), so we revert the change to _dependabot.yml_ and modify the entry for pip. For the original error, see: https://github.com/opensafely-actions/cohort-joiner/runs/5817692028.
