### PR TITLE
Remove rhs surprise

### DIFF
--- a/analysis/cohort_joiner.py
+++ b/analysis/cohort_joiner.py
@@ -63,11 +63,11 @@ def parse_args():
     )
     parser.add_argument(
         "--rhs",
-        dest="rhs_paths",
+        dest="rhs_path",
         required=True,
-        type=match_paths,
-        metavar="RHS_PATTERN",
-        help="Glob pattern for matching one input dataframe that will form the right-hand side of the join",
+        type=get_path,
+        metavar="RHS_FILE",
+        help="The input dataframe that will form the right-hand side of the join",
     )
     parser.add_argument(
         "--output-dir",
@@ -87,7 +87,7 @@ def check_paths(lhs_paths, rhs_path, output_path):
 def main():
     args = parse_args()
     lhs_paths = args.lhs_paths
-    rhs_path = args.rhs_paths[0]
+    rhs_path = args.rhs_path
     output_path = args.output_path
     check_paths(lhs_paths, rhs_path, output_path)
 

--- a/analysis/cohort_joiner.py
+++ b/analysis/cohort_joiner.py
@@ -74,6 +74,7 @@ def parse_args():
         dest="output_path",
         default="output/joined",
         type=get_path,
+        metavar="OUTPUT_DIR",
         help="The output directory. If it doesn't exist, then it will be created",
     )
     return parser.parse_args()

--- a/tests/test_cohort_joiner.py
+++ b/tests/test_cohort_joiner.py
@@ -138,7 +138,7 @@ def test_parse_args(tmp_path, monkeypatch):
     args = cohort_joiner.parse_args()
 
     assert args.lhs_paths == [tmp_path / "input_2021-01-01.csv"]
-    assert args.rhs_paths == [tmp_path / "input_ethnicity.csv"]
+    assert args.rhs_path == tmp_path / "input_ethnicity.csv"
     assert args.output_path == tmp_path / "output" / "joined"
 
 


### PR DESCRIPTION
The `--rhs` argument expects a glob, but only the first matching file is taken. Let's remove the surprise 🎉 and insist that the `--rhs` argument expects a path to an input dataframe (3b6d0c3).

Whilst we're here, let's also make a cosmetic change to the help text (706fc24). It's unlikely anyone will ever see it, but that doesn't mean it's not there.

Fixes #42